### PR TITLE
return a tarball stream instead of objects on download

### DIFF
--- a/src/docs.js
+++ b/src/docs.js
@@ -157,38 +157,7 @@ async function downloader(options) {
     Key: options.project + '/latest.tar.gz',
   }).createReadStream();
 
-  let output = {};
-  let extractor = tar.extract();
-
-  let downloadPromise = new Promise((resolve, reject) => {
-    extractor.on('entry', (header, stream, callback) => {
-      let data = [];
-
-      stream.on('data', function(chunk) {
-        data.push(chunk);
-      });
-
-      stream.on('end', () => {
-        output[header.name] = data.join('');
-        callback(); //ready for next entry
-      });
-
-      stream.resume(); //just auto drain the stream
-    });
-
-    extractor.on('finish', function() {
-      // all entries read
-      resolve();
-    });
-
-    extractor.on('error', function() {
-      reject();
-    });
-  });
-
-  readStream.pipe(zlib.Unzip()).pipe(extractor);
-  await downloadPromise;
-  return output;
+  return readStream.pipe(zlib.Unzip());
 }
 
 module.exports = {documenter, downloader};


### PR DESCRIPTION
This is necessary for work in taskcluster-docs
