### PR TITLE
make taskcluster-base a devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "recursive-readdir-sync": "^1.0.6",
     "s3-upload-stream": "^1.0.7",
     "tar-stream": "^1.5.2",
-    "taskcluster-base": "^5.1.1",
     "taskcluster-client": "^1.0.1"
   },
   "devDependencies": {
+    "taskcluster-base": "^5.1.1",
     "babel-compile": "^2.0.0",
     "babel-eslint": "^6.0.4",
     "babel-preset-taskcluster": "^2.3.0",


### PR DESCRIPTION
I didn't test this... Hopefully, we have a travis setup that will do that...
If not please double check that this won't break anything :)


Note: including tc-base as a dependency is pretty bad, especially in a library that is included by other services...