### PR TITLE
Add workers as tier

### DIFF
--- a/src/docs.js
+++ b/src/docs.js
@@ -34,6 +34,7 @@ async function documenter(options) {
     'integrations',
     'operations',
     'libraries',
+    'workers',
   ];
   assert(tiers.indexOf(options.tier) !== -1,
     `options.tier must be one of ${tiers.join(', ')}`);


### PR DESCRIPTION
Okay, I have no idea if this right...
@imbstack, @djmitche, I assume one or both of you have some grand design vision for docs organization...

I suspect we need two tiers for workers...
1. workers (generic-worker, docker-worker, taskcluster-worker, script-worker)
2. worker-types (b2gtest, github-worker, etc...)

1) would describe how tc-worker is architectured, the code, how to configure it and deploy it...
2) would document a specific deployment of tc-worker... ie. once I have a configuration file I want to generate the payload schema as well as documentation specific to this workerType...
I imagine each plugin in tc-worker would export docs, such that docs is exported depending on which plugins are enabled in the workerType configuration...