### PR TITLE
Updated docs.js for bug 1237575

### DIFF
--- a/src/docs.js
+++ b/src/docs.js
@@ -48,6 +48,11 @@ async function documenter(options) {
     return {name: path.join(dir || '', name)};
   }
 
+  function getDocumentationUrl() {
+    let referenceUrl = 'https://docs.taskcluster.net/reference/';
+    return referenceUrl + options.tier + '/' + options.project;
+  }
+
   let tarball = tar.pack();
 
   let metadata = {
@@ -137,11 +142,6 @@ async function documenter(options) {
         reject(error);
       });
     });
-
-  function getDocumentationUrl() {
-    let referenceUrl = "https://docs.taskcluster.net/reference/";
-    return referenceUrl + options.tier + '/' + options.project;
-  }
 
     // pipe the incoming filestream through compression and up to s3
     tgz.pipe(upload);

--- a/src/docs.js
+++ b/src/docs.js
@@ -13,6 +13,7 @@ let debug = require('debug')('taskcluster-lib-docs');
 
 async function documenter(options) {
   options = _.defaults({}, options, {
+    referenceUrl: 'https://docs.taskcluster.net/reference/',
     aws: null,
     credentials: undefined,
     project: null,
@@ -49,8 +50,7 @@ async function documenter(options) {
   }
 
   function getDocumentationUrl() {
-    let referenceUrl = 'https://docs.taskcluster.net/reference/';
-    return referenceUrl + options.tier + '/' + options.project;
+    return options.referenceUrl + options.tier + '/' + options.project;
   }
 
   let tarball = tar.pack();

--- a/src/docs.js
+++ b/src/docs.js
@@ -138,6 +138,11 @@ async function documenter(options) {
       });
     });
 
+  function getDocumentationUrl() {
+    let referenceUrl = "https://docs.taskcluster.net/reference/";
+    return referenceUrl + options.tier + '/' + options.project;
+  }
+
     // pipe the incoming filestream through compression and up to s3
     tgz.pipe(upload);
     await uploadPromise;


### PR DESCRIPTION
Added a new method in documenter function 'getDocumentationUrl' which returns the link to the documentation.