### PR TITLE
Added a property documentationUrl and removed getDocumentationUrl method for bug 1237575

### DIFF
--- a/src/docs.js
+++ b/src/docs.js
@@ -49,9 +49,7 @@ async function documenter(options) {
     return {name: path.join(dir || '', name)};
   }
 
-  function getDocumentationUrl() {
-    return options.referenceUrl + options.tier + '/' + options.project;
-  }
+  let documentationUrl = options.referenceUrl + options.tier + '/' + options.project;
 
   let tarball = tar.pack();
 
@@ -150,6 +148,7 @@ async function documenter(options) {
 
   return {
     tgz,
+    documentationUrl,
   };
 }
 


### PR DESCRIPTION
Earlier we were using a function `getDocumentationUrl` in documenter for getting the documentation link in tc-lib-app/src/app.js. But it is easier to return it as a property of `docs`(instance of tc-lib-docs) and use it in tc-lib-app.