### PR TITLE
Revert "Need yo prefix command with node"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "mocha .test/*_test.js"
   },
   "bin": {
-    "upload-project-docs": "node lib/upload-project-docs.js"
+    "upload-project-docs": "lib/upload-project-docs.js"
   },
   "files": [
     "lib"


### PR DESCRIPTION
Per https://docs.npmjs.com/files/package.json#bin the property value
should be a pathname, and in fact per
https://bugzilla.mozilla.org/show_bug.cgi?id=1424629 npm is trying to
`chmod` a pathname containing `node ` and failing.

This reverts commit 73c2929215642817a7f293f90fc8f16c644d7f52.